### PR TITLE
feat: add gitsigns.nvim for git diff visualization

### DIFF
--- a/nvim/lua/plugins/editor.lua
+++ b/nvim/lua/plugins/editor.lua
@@ -197,4 +197,93 @@ return {
     event = "VeryLazy",
     opts = {},
   },
+
+  -- Git差分表示
+  {
+    "lewis6991/gitsigns.nvim",
+    event = { "BufReadPre", "BufNewFile" },
+    opts = {
+      signs = {
+        add          = { text = '+' },
+        change       = { text = '~' },
+        delete       = { text = '_' },
+        topdelete    = { text = '‾' },
+        changedelete = { text = '~' },
+        untracked    = { text = '┆' },
+      },
+      signcolumn = true,  -- Sign columnにgit差分を表示
+      numhl      = false, -- 行番号のハイライト
+      linehl     = false, -- 行全体のハイライト
+      word_diff  = false, -- 単語単位の差分
+      watch_gitdir = {
+        interval = 1000,
+        follow_files = true
+      },
+      attach_to_untracked = true,
+      current_line_blame = false, -- 現在行のblame情報表示
+      current_line_blame_opts = {
+        virt_text = true,
+        virt_text_pos = 'eol', -- 'eol' | 'overlay' | 'right_align'
+        delay = 1000,
+        ignore_whitespace = false,
+      },
+      current_line_blame_formatter = '<author>, <author_time:%Y-%m-%d> - <summary>',
+      sign_priority = 6,
+      update_debounce = 100,
+      status_formatter = nil,
+      max_file_length = 40000,
+      preview_config = {
+        -- プレビューウィンドウの設定
+        border = 'single',
+        style = 'minimal',
+        relative = 'cursor',
+        row = 0,
+        col = 1
+      },
+      on_attach = function(bufnr)
+        local gitsigns = require('gitsigns')
+
+        local function map(mode, l, r, opts)
+          opts = opts or {}
+          opts.buffer = bufnr
+          vim.keymap.set(mode, l, r, opts)
+        end
+
+        -- ナビゲーション
+        map('n', ']c', function()
+          if vim.wo.diff then
+            vim.cmd.normal({']c', bang = true})
+          else
+            gitsigns.nav_hunk('next')
+          end
+        end, {desc = 'Next hunk'})
+
+        map('n', '[c', function()
+          if vim.wo.diff then
+            vim.cmd.normal({'[c', bang = true})
+          else
+            gitsigns.nav_hunk('prev')
+          end
+        end, {desc = 'Previous hunk'})
+
+        -- アクション
+        map('n', '<leader>hs', gitsigns.stage_hunk, {desc = 'Stage hunk'})
+        map('n', '<leader>hr', gitsigns.reset_hunk, {desc = 'Reset hunk'})
+        map('v', '<leader>hs', function() gitsigns.stage_hunk {vim.fn.line('.'), vim.fn.line('v')} end, {desc = 'Stage hunk'})
+        map('v', '<leader>hr', function() gitsigns.reset_hunk {vim.fn.line('.'), vim.fn.line('v')} end, {desc = 'Reset hunk'})
+        map('n', '<leader>hS', gitsigns.stage_buffer, {desc = 'Stage buffer'})
+        map('n', '<leader>hu', gitsigns.undo_stage_hunk, {desc = 'Undo stage hunk'})
+        map('n', '<leader>hR', gitsigns.reset_buffer, {desc = 'Reset buffer'})
+        map('n', '<leader>hp', gitsigns.preview_hunk, {desc = 'Preview hunk'})
+        map('n', '<leader>hb', function() gitsigns.blame_line{full=true} end, {desc = 'Blame line'})
+        map('n', '<leader>tb', gitsigns.toggle_current_line_blame, {desc = 'Toggle blame'})
+        map('n', '<leader>hd', gitsigns.diffthis, {desc = 'Diff this'})
+        map('n', '<leader>hD', function() gitsigns.diffthis('~') end, {desc = 'Diff this ~'})
+        map('n', '<leader>td', gitsigns.toggle_deleted, {desc = 'Toggle deleted'})
+
+        -- Text object
+        map({'o', 'x'}, 'ih', ':<C-U>Gitsigns select_hunk<CR>', {desc = 'Select hunk'})
+      end
+    },
+  },
 }


### PR DESCRIPTION
## Summary
Add visual git diff indicators in Neovim editor using gitsigns.nvim plugin to improve code change awareness.

## Changes
- ✅ Added gitsigns.nvim plugin configuration in `nvim/lua/plugins/editor.lua`
- ✅ Configured sign column indicators for added (+), modified (~), and deleted (_) lines
- ✅ Added keymaps for navigating and managing git hunks
- ✅ Configured preview and blame features

## Features Added
### Visual Indicators
- `+` for added lines
- `~` for modified lines
- `_` for deleted lines at cursor
- `‾` for deleted lines above
- `┆` for untracked files

### Key Mappings
- `]c` / `[c` - Navigate to next/previous hunk
- `<leader>hs` - Stage hunk
- `<leader>hr` - Reset hunk
- `<leader>hp` - Preview hunk changes
- `<leader>hb` - Show blame for current line
- `<leader>tb` - Toggle blame display
- `<leader>td` - Toggle deleted lines display

## Testing
- [x] Docker build completes successfully
- [x] Plugin loads without errors (`Gitsigns loaded: true`)
- [x] Visual indicators appear in sign column
- [x] Key mappings work as expected

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)