### PR TITLE
feat: simplify LSP configuration and improve diagnostic display

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ ENV DOCKER_BUILD=1
 RUN nvim --headless "+Lazy! sync" +qa || true && \
     nvim --headless -c "TSUpdateSync" +qa || true && \
     nvim --headless \
-        -c "MasonInstall lua-language-server pyright gopls rust-analyzer typescript-language-server" \
+        -c "MasonInstall lua-language-server gopls rust-analyzer typescript-language-server" \
         -c "MasonInstall dockerfile-language-server yaml-language-server json-lsp bash-language-server ruff" \
         -c "MasonInstall gofumpt golangci-lint prettier stylua shellcheck shfmt" \
         +qa 2>/dev/null || true

--- a/nvim/dein.toml
+++ b/nvim/dein.toml
@@ -184,124 +184,124 @@ on_ft = 'rust'
 # source ~/.config/nvim/plugins/rust.rc.vim
 #'''
 
-[[plugins]]
-repo = 'neoclide/coc.nvim'
-rev = 'release'
-build = '''
-  git checkout release
-'''
-hook_add = '''
-" coc extensions
-" let g:coc_global_extensions = [
-"     \ 'coc-json',
-"     \ 'coc-sql',
-"     \ 'coc-docker',
-"     \ 'coc-pyright',
-"     \ 'coc-go',
-"     \ 'coc-git',
-"     \ 'coc-json',
-"     \ 'coc-yaml',
-"     \ ]
-
-"LightLineにcoc.nvimのステータスを載せます
-set noshowmode
-let g:lightline = {
-  \'colorscheme': 'powerline',
-  \'separator': { 'left': '', 'right': '' },
-  \'subseparator' :{ 'left': '|', 'right': '|' },
-  \'active': {
-    \'left': [
-      \['mode', 'paste'],
-      \['gitbranch', 'readonly', 'repofilename', 'modified']
-    \],
-    \'right': [
-      \['coc']
-    \]
-  \},
-  \'component_function': {
-    \'coc': 'coc#status',
-    \'gitbranch': 'FugitiveHead',
-    \'repofilename': 'LightlineFilename',
-  \}
-\}
-function! LightlineFilename()
-  let root = fnamemodify(get(b:, 'git_dir'), ':h')
-  let path = expand('%:p')
-  if path[:len(root)-1] ==# root
-    return path[len(root)+1:]
-  endif
-  return expand('%')
-endfunction
-
-" TextEdit might fail if hidden is not set.
-set hidden
-
-" Some servers have issues with backup files, see #649.
-set nobackup
-set nowritebackup
-
-" Give more space for displaying messages.
-set cmdheight=2
-
-" Having longer updatetime (default is 4000 ms = 4 s) leads to noticeable
-" delays and poor user experience.
-set updatetime=300
-
-" Don't pass messages to |ins-completion-menu|.
-set shortmess+=c
-
-" Use tab for trigger completion with characters ahead and navigate.
-" NOTE: Use command ':verbose imap <tab>' to make sure tab is not mapped by
-" other plugin before putting this into your config.
-inoremap <silent><expr> <TAB>
-      \ pumvisible() ? "\<C-n>" :
-      \ <SID>check_back_space() ? "\<TAB>" :
-      \ coc#refresh()
-inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
-
-function! s:check_back_space() abort
-  let col = col('.') - 1
-  return !col || getline('.')[col - 1]  =~# '\s'
-endfunction
-
-" Use <c-space> to trigger completion.
-if has('nvim')
-  inoremap <silent><expr> <c-space> coc#refresh()
-else
-  inoremap <silent><expr> <c-@> coc#refresh()
-endif
-
-" Use `[g` and `]g` to navigate diagnostics
-" Use `:CocDiagnostics` to get all diagnostics of current buffer in location list.
-nmap <silent> <C-p> <Plug>(coc-diagnostic-prev)
-nmap <silent> <C-n> <Plug>(coc-diagnostic-next)
-
-" Highlight the symbol and its references when holding the cursor.
-autocmd ColorScheme * highlight CocHighlightText ctermbg=238
-autocmd CursorHold * silent call CocActionAsync('highlight')
-
-" diagnostics の色変
-autocmd ColorScheme * highlight CocErrorSign ctermfg=1 cterm=BOLD
-autocmd ColorScheme * highlight CocWarningSign ctermfg=33 cterm=BOLD
-autocmd ColorScheme * highlight link CocErrorHighlight CocErrorSign
-autocmd ColorScheme * highlight link CocWarningHighlight CocWarningSign
-" autocmd ColorScheme * highlight CocErrorLine ctermfg=138 cterm=BOLD
-" autocmd ColorScheme * highlight CocWarningLine ctermfg=74 cterm=BOLD
-
-" guchio shortcut
-" CocList
-nmap ,l :<C-u>CocList<cr>
-" Hover
-nmap K :<C-u>call CocAction('doHover')<cr>
-" Definition
-nmap <C-]> <Plug>(coc-definition)
-" References
-nmap <C-[> <Plug>(coc-references)
-" Rename
-nmap <silent> ,r <Plug>(coc-rename)
-" Format
-xmap ,a <Plug>(coc-format)
-nmap ,a <Plug>(coc-format)
-" sort imports on save
-" autocmd BufWrite *.py :CocCommand python.sortImports
-'''
+# [[plugins]]
+# repo = 'neoclide/coc.nvim'
+# rev = 'release'
+# build = '''
+#   git checkout release
+# '''
+# hook_add = '''
+# " coc extensions
+# " let g:coc_global_extensions = [
+# "     \ 'coc-json',
+# "     \ 'coc-sql',
+# "     \ 'coc-docker',
+# "     \ 'coc-pyright',
+# "     \ 'coc-go',
+# "     \ 'coc-git',
+# "     \ 'coc-json',
+# "     \ 'coc-yaml',
+# "     \ ]
+# 
+# "LightLineにcoc.nvimのステータスを載せます
+# set noshowmode
+# let g:lightline = {
+#   \'colorscheme': 'powerline',
+#   \'separator': { 'left': '', 'right': '' },
+#   \'subseparator' :{ 'left': '|', 'right': '|' },
+#   \'active': {
+#     \'left': [
+#       \['mode', 'paste'],
+#       \['gitbranch', 'readonly', 'repofilename', 'modified']
+#     \],
+#     \'right': [
+#       \['coc']
+#     \]
+#   \},
+#   \'component_function': {
+#     \'coc': 'coc#status',
+#     \'gitbranch': 'FugitiveHead',
+#     \'repofilename': 'LightlineFilename',
+#   \}
+# \}
+# function! LightlineFilename()
+#   let root = fnamemodify(get(b:, 'git_dir'), ':h')
+#   let path = expand('%:p')
+#   if path[:len(root)-1] ==# root
+#     return path[len(root)+1:]
+#   endif
+#   return expand('%')
+# endfunction
+# 
+# " TextEdit might fail if hidden is not set.
+# set hidden
+# 
+# " Some servers have issues with backup files, see #649.
+# set nobackup
+# set nowritebackup
+# 
+# " Give more space for displaying messages.
+# set cmdheight=2
+# 
+# " Having longer updatetime (default is 4000 ms = 4 s) leads to noticeable
+# " delays and poor user experience.
+# set updatetime=300
+# 
+# " Don't pass messages to |ins-completion-menu|.
+# set shortmess+=c
+# 
+# " Use tab for trigger completion with characters ahead and navigate.
+# " NOTE: Use command ':verbose imap <tab>' to make sure tab is not mapped by
+# " other plugin before putting this into your config.
+# inoremap <silent><expr> <TAB>
+#       \ pumvisible() ? "\<C-n>" :
+#       \ <SID>check_back_space() ? "\<TAB>" :
+#       \ coc#refresh()
+# inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
+# 
+# function! s:check_back_space() abort
+#   let col = col('.') - 1
+#   return !col || getline('.')[col - 1]  =~# '\s'
+# endfunction
+# 
+# " Use <c-space> to trigger completion.
+# if has('nvim')
+#   inoremap <silent><expr> <c-space> coc#refresh()
+# else
+#   inoremap <silent><expr> <c-@> coc#refresh()
+# endif
+# 
+# " Use `[g` and `]g` to navigate diagnostics
+# " Use `:CocDiagnostics` to get all diagnostics of current buffer in location list.
+# " nmap <silent> <C-p> <Plug>(coc-diagnostic-prev)
+# " nmap <silent> <C-n> <Plug>(coc-diagnostic-next)
+# 
+# " Highlight the symbol and its references when holding the cursor.
+# autocmd ColorScheme * highlight CocHighlightText ctermbg=238
+# autocmd CursorHold * silent call CocActionAsync('highlight')
+# 
+# " diagnostics の色変
+# autocmd ColorScheme * highlight CocErrorSign ctermfg=1 cterm=BOLD
+# autocmd ColorScheme * highlight CocWarningSign ctermfg=33 cterm=BOLD
+# autocmd ColorScheme * highlight link CocErrorHighlight CocErrorSign
+# autocmd ColorScheme * highlight link CocWarningHighlight CocWarningSign
+# " autocmd ColorScheme * highlight CocErrorLine ctermfg=138 cterm=BOLD
+# " autocmd ColorScheme * highlight CocWarningLine ctermfg=74 cterm=BOLD
+# 
+# " guchio shortcut
+# " CocList
+# nmap ,l :<C-u>CocList<cr>
+# " Hover
+# nmap K :<C-u>call CocAction('doHover')<cr>
+# " Definition
+# nmap <C-]> <Plug>(coc-definition)
+# " References
+# nmap <C-[> <Plug>(coc-references)
+# " Rename
+# nmap <silent> ,r <Plug>(coc-rename)
+# " Format
+# xmap ,a <Plug>(coc-format)
+# nmap ,a <Plug>(coc-format)
+# " sort imports on save
+# " autocmd BufWrite *.py :CocCommand python.sortImports
+# '''

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -26,7 +26,6 @@ vim.opt.timeoutlen = 500  -- マッピングのタイムアウト（ミリ秒）
 vim.opt.ttimeoutlen = 10  -- キーコードのタイムアウト（10msは安全な値）
 vim.opt.cmdheight = 2
 vim.opt.shortmess:append("c")
-vim.opt.signcolumn = "yes"
 
 -- 見た目系
 vim.opt.number = true
@@ -38,6 +37,7 @@ vim.opt.wildmode = "list:longest"
 vim.opt.cursorline = true
 vim.opt.termguicolors = true
 vim.opt.background = "dark"
+vim.opt.signcolumn = "auto"  -- サイン列は必要時のみ表示
 
 -- Tab系
 vim.opt.list = true
@@ -49,6 +49,10 @@ vim.opt.shiftwidth = 4
 -- その他
 vim.opt.mouse = "a"
 vim.opt.clipboard = "unnamedplus"
+
+-- タグファイルを無効化（LSPを使用するため）
+vim.opt.tags = ""
+vim.opt.tagstack = false
 
 -- ファイル保存時に末尾に改行を追加（POSIX準拠）
 vim.opt.fixeol = true  -- ファイル末尾に改行がなければ追加

--- a/nvim/lua/plugins/editor.lua
+++ b/nvim/lua/plugins/editor.lua
@@ -33,8 +33,6 @@ return {
           path_display = { "truncate" },
           mappings = {
             i = {
-              ["<C-n>"] = actions.cycle_history_next,
-              ["<C-p>"] = actions.cycle_history_prev,
               ["<C-j>"] = actions.move_selection_next,
               ["<C-k>"] = actions.move_selection_previous,
               ["<C-c>"] = actions.close,
@@ -133,7 +131,7 @@ return {
       "nvim-tree/nvim-web-devicons",
     },
     keys = {
-      { "<C-n>", "<cmd>NvimTreeToggle<cr>", desc = "Toggle file tree" },
+      { ",e", "<cmd>NvimTreeToggle<cr>", desc = "Toggle file tree" },
       { ",n", "<cmd>NvimTreeFindFile<cr>", desc = "Find current file in tree" },
     },
     opts = {


### PR DESCRIPTION
## 概要
Neovim のLSP設定を簡素化し、診断表示の改善を試みました。

## 変更内容
### LSP設定の改善
- mason-lspconfig v2 APIへの移行（handlers パターン使用）
- 約230行→180行にコード削減
- pyrightを削除し、ruffのみでPythonサポート

### バグ修正
- LspInfoコマンドの上書き問題を修正（LspHealthに変更）
- deprecated警告の解消（vim.diagnostic.jump → goto_prev/next）
- tagsファイルエラーへの対処

### 診断表示の改善（部分的）
- E/Wサイン列を無効化する設定追加
- 波線と背景色のハイライト設定
- キーマッピングの改善（gd/gD/gr追加）

## 未解決の問題
- Ctrl+N/Pでの診断ナビゲーションが動作しない
- 波線（undercurl）が表示されない（端末/tmux環境依存）
- LSPのバッファへのattachに問題がある可能性

## テスト
```bash
docker build -t nvim .
docker run -it --rm -v $(pwd):/workspace nvim test_diagnostic.py
```

## 注意
完全に動作しない部分があるため、記録用のPRとして作成しています。
今後の改善の参考にしてください。

🤖 Generated with [Claude Code](https://claude.ai/code)