### PR TITLE
fix: avoid duplicate definitions from LSP

### DIFF
--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -27,7 +27,8 @@ return {
         "jsonls",        -- JSON
         "bashls",        -- Bash
       },
-      automatic_installation = false,  -- Dockerでは事前インストール済み
+      -- disable automatic server enabling to avoid duplicate LSP clients
+      automatic_enable = false,
     },
   },
 


### PR DESCRIPTION
## Summary
- disable mason-lspconfig's automatic LSP enabling so servers aren't started twice
- prevents duplicate locations when jumping to definitions

## Testing
- `luac -p nvim/lua/plugins/lsp.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a72e3286fc832fb1cea53bfdfcff6e