### PR TITLE
Disable pyright diagnostics

### DIFF
--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -141,6 +141,10 @@ return {
           },
         },
         pyright = {
+          -- Disable pyright diagnostics; use ruff for linting instead
+          handlers = {
+            ["textDocument/publishDiagnostics"] = function() end,
+          },
           settings = {
             python = {
               analysis = {


### PR DESCRIPTION
## Summary
- silence pyright diagnostics while keeping the server for analysis

## Testing
- `nvim --headless -u nvim/init.lua -c 'quit'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a761da20c4832f98b24267d9d0d083