### PR TITLE
feat: add VS Code–like floating LSP peek (glance.nvim)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Two solutions:
 
 See: docker container attach reference, docker config.json man page.
 
+### Glance `close` error on `<CR>`
+
+If you see `... attempt to call method 'close' (a nil value)` when pressing `<CR>` in the Glance list, ensure you're on this version. The close is now scheduled and guarded with `is_open()`.
+
 ## Key Mappings
 
 ### General
@@ -79,8 +83,8 @@ See: docker container attach reference, docker config.json man page.
 ### LSP
 
 - `K` - Hover documentation
-- `<C-]>` - VS Code–like floating peek for definition (auto-closes; single result jumps)
-- `<C-[>` - VS Code–like floating peek for references (auto-closes; single result jumps)
+- `<C-]>` - VS Code–like floating peek for definition (auto-closes after jump; single result jumps)
+- `<C-[>` - VS Code–like floating peek for references (auto-closes after jump; ignores current location for single-result jump)
 - `,r` - Rename
 - `,a` - Format code
 - `[d` - Previous diagnostic

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Dockerized Neovim development environment with modern configuration (2025).
 - **Native LSP** with mason.nvim for language server management
 - **Telescope** for fuzzy finding
 - **Treesitter** for better syntax highlighting
+- **glance.nvim** for VS Code–like LSP peek UI
 - Pre-configured for Python, Go, TypeScript, Rust development
 - **uv** for Python package management
 
@@ -78,8 +79,8 @@ See: docker container attach reference, docker config.json man page.
 ### LSP
 
 - `K` - Hover documentation
-- `<C-]>` - Go to definition
-- `<C-[>` - Find references
+- `<C-]>` - VS Code–like floating peek for definition (auto-closes; single result jumps)
+- `<C-[>` - VS Code–like floating peek for references (auto-closes; single result jumps)
 - `,r` - Rename
 - `,a` - Format code
 - `[d` - Previous diagnostic

--- a/nvim/lua/plugins/glance.lua
+++ b/nvim/lua/plugins/glance.lua
@@ -5,6 +5,17 @@ return {
     local glance = require("glance")
     local actions = glance.actions
 
+    local function jump_and_close(fn)
+      return function(...)
+        fn(...)
+        vim.schedule(function()
+          if glance.is_open() then
+            actions.close()
+          end
+        end)
+      end
+    end
+
     glance.setup({
       -- VSCode の Peek 風に常時フローティング
       detached = true,
@@ -14,7 +25,24 @@ return {
       -- 結果 1 件ならウィンドウを出さず即ジャンプ
       hooks = {
         before_open = function(results, open, jump, method)
-          if #results == 1 then
+          if method == "references" then
+            local uri = vim.uri_from_bufnr(0)
+            local pos = vim.api.nvim_win_get_cursor(0)
+            local line, col = pos[1] - 1, pos[2]
+            local filtered = {}
+            for _, res in ipairs(results) do
+              local r_uri = res.uri or res.targetUri
+              local r_range = res.range or res.targetSelectionRange
+              if not (r_uri == uri and r_range.start.line == line and r_range.start.character == col) then
+                table.insert(filtered, res)
+              end
+            end
+            results = filtered
+          end
+
+          if #results == 0 then
+            return
+          elseif #results == 1 then
             jump(results[1])
           else
             open(results)
@@ -25,14 +53,11 @@ return {
       -- ジャンプ後に自動クローズ
       mappings = {
         list = {
-          ["<CR>"] = function()
-            actions.jump()
-            actions.close()
-          end,
+          ["<CR>"] = jump_and_close(actions.jump),
           -- お好みで分割やタブジャンプ後も閉じる
-          ["s"] = function() actions.jump_split(); actions.close() end,
-          ["v"] = function() actions.jump_vsplit(); actions.close() end,
-          ["t"] = function() actions.jump_tab(); actions.close() end,
+          ["s"] = jump_and_close(actions.jump_split),
+          ["v"] = jump_and_close(actions.jump_vsplit),
+          ["t"] = jump_and_close(actions.jump_tab),
           ["q"] = actions.close,
           ["<Esc>"] = actions.close,
         },
@@ -45,6 +70,6 @@ return {
 
     -- 既存の UX を維持しつつ Glance に切り替え
     vim.keymap.set("n", "<C-]>", "<Cmd>Glance definitions<CR>", { desc = "Peek definitions (Glance)" })
-    vim.keymap.set("n", "<C-[>", "<Cmd>Glance references<CR>",  { desc = "Peek references (Glance)" })
+    vim.keymap.set("n", "<C-[>", "<Cmd>Glance references<CR>", { desc = "Peek references (Glance)" })
   end,
 }

--- a/nvim/lua/plugins/glance.lua
+++ b/nvim/lua/plugins/glance.lua
@@ -1,0 +1,50 @@
+return {
+  "dnlhc/glance.nvim",
+  event = "LspAttach",
+  config = function()
+    local glance = require("glance")
+    local actions = glance.actions
+
+    glance.setup({
+      -- VSCode の Peek 風に常時フローティング
+      detached = true,
+      height = 18,
+      preview_win_opts = { number = true, cursorline = true, wrap = true },
+
+      -- 結果 1 件ならウィンドウを出さず即ジャンプ
+      hooks = {
+        before_open = function(results, open, jump, method)
+          if #results == 1 then
+            jump(results[1])
+          else
+            open(results)
+          end
+        end,
+      },
+
+      -- ジャンプ後に自動クローズ
+      mappings = {
+        list = {
+          ["<CR>"] = function()
+            actions.jump()
+            actions.close()
+          end,
+          -- お好みで分割やタブジャンプ後も閉じる
+          ["s"] = function() actions.jump_split(); actions.close() end,
+          ["v"] = function() actions.jump_vsplit(); actions.close() end,
+          ["t"] = function() actions.jump_tab(); actions.close() end,
+          ["q"] = actions.close,
+          ["<Esc>"] = actions.close,
+        },
+        preview = {
+          ["q"] = actions.close,
+          ["<Esc>"] = actions.close,
+        },
+      },
+    })
+
+    -- 既存の UX を維持しつつ Glance に切り替え
+    vim.keymap.set("n", "<C-]>", "<Cmd>Glance definitions<CR>", { desc = "Peek definitions (Glance)" })
+    vim.keymap.set("n", "<C-[>", "<Cmd>Glance references<CR>",  { desc = "Peek references (Glance)" })
+  end,
+}

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -96,8 +96,6 @@ return {
         local opts = { noremap = true, silent = true, buffer = bufnr }
 
         vim.keymap.set("n", "K", vim.lsp.buf.hover, opts)
-        vim.keymap.set("n", "<C-]>", vim.lsp.buf.definition, opts)
-        vim.keymap.set("n", "<C-[>", vim.lsp.buf.references, opts)
         vim.keymap.set("n", ",r", vim.lsp.buf.rename, opts)
         vim.keymap.set("n", ",a", vim.lsp.buf.format, opts)
         vim.keymap.set("v", ",a", vim.lsp.buf.format, opts)


### PR DESCRIPTION
## Summary
- add glance.nvim for floating peek windows and auto-closing jumps
- map `<C-]>` and `<C-[>` to Glance definitions/references
- document new peek behavior and keymaps in README

## Testing
- `nvim --headless --cmd "set rtp+=." -u init.lua -c "q"` *(fails: Failed to source `/root/.local/share/nvim/lazy/nvim-lspconfig/plugin/lspconfig.lua`)*

------
https://chatgpt.com/codex/tasks/task_e_68a7dd5d640c832f95db2d17703ae55d