### PR TITLE
feat(ui): clearer LSP diagnostics (colored signs & undercurls) + toggle virtual lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Available themes:
 - `gruvbox` - Retro style theme
 - `kanagawa` - Japanese-inspired calm theme (wave/dragon/lotus variants)
 
+### Diagnostic UI
+
+Diagnostics now use colored signs and undercurls so errors and warnings stand out without gray blocks.
+Messages appear inline by default, but you can press `,x` to toggle between inline virtual text and multi-line virtual lines.
+A Nerd Font provides the best icons; ASCII characters are used if it's unavailable.
+Some terminals or tmux may render the undercurl as a normal underline, but the signcolumn icons still indicate severity.
+
 ## Configuration
 
 The configuration is written in Lua and located in:

--- a/nvim/lua/plugins/diagnostics.lua
+++ b/nvim/lua/plugins/diagnostics.lua
@@ -1,0 +1,95 @@
+return {
+  {
+    "ErichDonGubler/lsp_lines.nvim",
+    event = "VeryLazy",
+    config = function()
+      local ok_lines, lsp_lines = pcall(require, "lsp_lines")
+      if ok_lines then lsp_lines.setup() end
+
+      -- Icons (fallback to ASCII if Nerd Font isn't available)
+      local nerd = vim.g.have_nerd_font ~= false
+      local icons = nerd and {
+        Error = "", Warn = "", Info = "", Hint = "",
+      } or {
+        Error = "E", Warn = "W", Info = "I", Hint = "H",
+      }
+
+      for type, icon in pairs(icons) do
+        local hl = "DiagnosticSign" .. type
+        vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = "" })
+      end
+
+      -- Diagnostic config
+      vim.diagnostic.config({
+        signs = true,
+        underline = true,
+        severity_sort = true,
+        update_in_insert = false,
+        float = { border = "rounded", source = "if_many", scope = "cursor" },
+        virtual_lines = false,
+        virtual_text = {
+          spacing = 1,
+          source = "if_many",
+          prefix = function(diag)
+            local s = diag.severity
+            local map = {
+              [vim.diagnostic.severity.ERROR] = icons.Error,
+              [vim.diagnostic.severity.WARN]  = icons.Warn,
+              [vim.diagnostic.severity.INFO]  = icons.Info,
+              [vim.diagnostic.severity.HINT]  = icons.Hint,
+            }
+            return map[s] or "●"
+          end,
+          -- show only first line to avoid wrapping
+          format = function(d)
+            return (d.message:gsub("\n.*$", ""))
+          end,
+        },
+      })
+
+      -- Palette (visible on dark themes)
+      local palette = {
+        error = "#e86671",
+        warn  = "#e5c07b",
+        info  = "#61afef",
+        hint  = "#98c379",
+      }
+
+      local function sethl(name, spec) pcall(vim.api.nvim_set_hl, 0, name, spec) end
+      local function apply_hl()
+        -- no background blocks; just colored text/signs
+        sethl("DiagnosticError", { fg = palette.error, bg = "NONE" })
+        sethl("DiagnosticWarn",  { fg = palette.warn,  bg = "NONE" })
+        sethl("DiagnosticInfo",  { fg = palette.info,  bg = "NONE" })
+        sethl("DiagnosticHint",  { fg = palette.hint,  bg = "NONE" })
+
+        -- virtual text (subtle)
+        sethl("DiagnosticVirtualTextError", { fg = palette.error, bg = "NONE", italic = true })
+        sethl("DiagnosticVirtualTextWarn",  { fg = palette.warn,  bg = "NONE", italic = true })
+        sethl("DiagnosticVirtualTextInfo",  { fg = palette.info,  bg = "NONE", italic = true })
+        sethl("DiagnosticVirtualTextHint",  { fg = palette.hint,  bg = "NONE", italic = true })
+
+        -- colored undercurls
+        sethl("DiagnosticUnderlineError", { undercurl = true, sp = palette.error })
+        sethl("DiagnosticUnderlineWarn",  { undercurl = true, sp = palette.warn })
+        sethl("DiagnosticUnderlineInfo",  { undercurl = true, sp = palette.info })
+        sethl("DiagnosticUnderlineHint",  { undercurl = true, sp = palette.hint })
+      end
+      apply_hl()
+      vim.api.nvim_create_autocmd("ColorScheme", { callback = apply_hl })
+
+      -- Toggle virtual lines <-> virtual text
+      vim.keymap.set("n", ",x", function()
+        local cfg = vim.diagnostic.config()
+        local use_lines = not cfg.virtual_lines
+        vim.diagnostic.config({
+          virtual_lines = use_lines,
+          virtual_text  = not use_lines,
+        })
+        if use_lines and not ok_lines then
+          vim.notify("virtual_lines enabled but lsp_lines.nvim missing", vim.log.levels.WARN)
+        end
+      end, { desc = "Toggle diagnostics: virtual lines <-> virtual text" })
+    end,
+  },
+}

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -50,24 +50,9 @@ return {
         vim.cmd("checkhealth lsp")
       end, { desc = "Show LSP information" })
 
-      -- 診断表示の設定
-      vim.diagnostic.config({
-        virtual_text = false, -- 仮想テキストは非表示（軽量化）
-        signs = true,
-        underline = true,
-        update_in_insert = false,
-        severity_sort = true,
-        float = {
-          border = "rounded",
-          source = "always",
-          header = "",
-          prefix = "",
-        },
-      })
-
-      -- カーソルホールド時に浮動ウィンドウで診断を表示
-      vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
-        callback = function()
+        -- カーソルホールド時に浮動ウィンドウで診断を表示
+        vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
+          callback = function()
           vim.diagnostic.open_float(nil, {
             focusable = false,
             close_events = {
@@ -84,15 +69,8 @@ return {
         end,
       })
 
-      -- 診断サインをより見やすく
-      local signs = { Error = "✗", Warn = "⚠", Hint = "💡", Info = "ℹ" }
-      for type, icon in pairs(signs) do
-        local hl = "DiagnosticSign" .. type
-        vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = hl })
-      end
-
-      -- LSPキーマップ
-      local on_attach = function(client, bufnr)
+        -- LSPキーマップ
+        local on_attach = function(client, bufnr)
         local opts = { noremap = true, silent = true, buffer = bufnr }
 
         vim.keymap.set("n", "K", vim.lsp.buf.hover, opts)


### PR DESCRIPTION
## Summary
- add diagnostics plugin with colored signs, undercurls, and subtle virtual text
- support toggling between inline virtual text and virtual lines with `,x`
- document diagnostic UI and toggle in README

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f03e0c8c832f82b777db84a2c623