### PR TITLE
fix: use user go cache

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,13 @@ if [ "$HOME" != "/root" ]; then
     if [ ! -e "$HOME/.cache/nvim" ]; then
         ln -sf /root/.cache/nvim "$HOME/.cache/nvim"
     fi
+
+    # Goのモジュールキャッシュとビルドディレクトリを設定
+    mkdir -p "$HOME/go/pkg/mod" "$HOME/.cache/go-build"
+    export GOPATH="$HOME/go"
+    export GOMODCACHE="$HOME/go/pkg/mod"
+    export GOCACHE="$HOME/.cache/go-build"
+    export PATH="$PATH:$GOPATH/bin"
 fi
 
 # Neovimを起動


### PR DESCRIPTION
## Summary
- ensure gopls uses user-writable Go module cache

## Testing
- `bash -n entrypoint.sh`
- `shellcheck entrypoint.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac099314e8832faf9505242289ba6f