### PR TITLE
feat(tree): focus current file on toggle and show relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you see `... attempt to call method 'close' (a nil value)` when pressing `<CR
 
 ### File Tree
 
-- `<C-e>` - Toggle file tree
+- `<C-e>` - Toggle file tree and jump to current file
 - `,n` - Find current file in tree
 
 ### Comments
@@ -111,6 +111,7 @@ If you see `... attempt to call method 'close' (a nil value)` when pressing `<CR
 
 - `,t` - Select color theme (interactive menu)
 - `,p` - Preview markdown files
+- Status line displays file path relative to current directory
 
 Available themes:
 

--- a/nvim/lua/plugins/editor.lua
+++ b/nvim/lua/plugins/editor.lua
@@ -133,7 +133,7 @@ return {
       "nvim-tree/nvim-web-devicons",
     },
     keys = {
-      { "<C-e>", "<cmd>NvimTreeToggle<cr>", desc = "Toggle file tree" },
+      { "<C-e>", "<cmd>NvimTreeFindFileToggle<cr>", desc = "Toggle file tree" },
       { ",n", "<cmd>NvimTreeFindFile<cr>", desc = "Find current file in tree" },
     },
     opts = {

--- a/nvim/lua/plugins/ui.lua
+++ b/nvim/lua/plugins/ui.lua
@@ -20,7 +20,7 @@ return {
       sections = {
         lualine_a = { "mode" },
         lualine_b = { "branch", "diff", "diagnostics" },
-        lualine_c = { "filename" },
+        lualine_c = { { "filename", path = 1 } },
         lualine_x = { "encoding", "fileformat", "filetype" },
         lualine_y = { "progress" },
         lualine_z = { "location" },


### PR DESCRIPTION
## Summary
- focus current file when toggling NvimTree with `<C-e>`
- display file path relative to current directory in statusline
- document tree toggle behavior and relative statusline path

## Testing
- `luac -p nvim/lua/plugins/ui.lua`
- `luac -p nvim/lua/plugins/editor.lua`
- `nvim --headless -u nvim/init.lua -c 'q'` *(fails: No specs found for module "plugins"; Vim:E185: Cannot find color scheme 'hybrid')*


------
https://chatgpt.com/codex/tasks/task_e_68b25d8c1f40832fb9ae262d12e8fcb1