### PR TITLE
feat: configure ruff with project settings

### DIFF
--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -161,7 +161,10 @@ return {
             },
           },
         },
-        ruff = {},
+        ruff = {
+          root_dir = require("lspconfig.util").root_pattern("pyproject.toml", ".git"),
+          settings = { args = { "--config", "pyproject.toml" } },
+        },
         ts_ls = {},
         rust_analyzer = {},
         dockerls = {},


### PR DESCRIPTION
## Summary
- configure Ruff LSP to use project config

## Testing
- `nvim --headless -u nvim/init.lua '+MasonInstall ruff ruff-lsp' +qa` *(failed: No specs found for module "plugins")*
- `XDG_CONFIG_HOME=$PWD nvim --headless test.py '+LspInfo' +qa` *(failed: nvim-lspconfig requires Nvim version 0.10)*

------
https://chatgpt.com/codex/tasks/task_e_68ba728490e0832faf671abbb4646743